### PR TITLE
Update Sass-lint dependency to use latest version

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
   "homepage": "https://github.com/sasstools/gulp-sass-lint#readme",
   "dependencies": {
     "gulp-util": "^3.0.6",
-    "sass-lint": "0.1.0-beta.2",
+    "sass-lint": "^1.0.0",
     "through2": "^2.0.0"
   },
   "devDependencies": {


### PR DESCRIPTION
Makes sure that gulp-sass-lint will use the latest version of sass-lint. Currently it still uses the beta.

Happy to change and specify 1.0.0 if required.
