### PR TITLE
Bump sass-lint version to 1.1.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
   "homepage": "https://github.com/sasstools/gulp-sass-lint#readme",
   "dependencies": {
     "gulp-util": "^3.0.6",
-    "sass-lint": "^1.0.0",
+    "sass-lint": "^1.1.0",
     "through2": "^2.0.0"
   },
   "devDependencies": {


### PR DESCRIPTION
Would be nice if gulp-sass-lint gets updated to the latest sass-lint (1.1.0)
