### PR TITLE
Use flush function in failOnError to wait for all errors

### DIFF
--- a/index.js
+++ b/index.js
@@ -76,7 +76,7 @@ sassLint.failOnError = function () {
 
     this.push(file);
     cb();
-  }, function () {
+  }, function (cb) {
     var errorMessage;
 
     if (filesWithErrors.length > 0) {
@@ -86,6 +86,8 @@ sassLint.failOnError = function () {
 
       this.emit('error', new PluginError(PLUGIN_NAME, errorMessage));
     }
+
+    cb();
   });
 
   return compile;

--- a/index.js
+++ b/index.js
@@ -59,25 +59,36 @@ sassLint.format = function () {
 }
 
 sassLint.failOnError = function () {
-  var compile = through.obj(function (file, encoding, cb) {
+  var filesWithErrors = [];
+  var compile = through({objectMode: true}, function (file, encoding, cb) {
     if (file.isNull()) {
       return cb();
     }
+
     if (file.isStream()) {
       this.emit('error', new PluginError(PLUGIN_NAME, 'Streams are not supported!'));
       return cb();
     }
 
     if (file.sassLint[0].errorCount > 0) {
-      this.emit('error', new PluginError(PLUGIN_NAME, file.sassLint[0].errorCount + ' errors detected in ' + file.relative));
-      return cb();
+      filesWithErrors.push(file);
     }
 
     this.push(file);
     cb();
+  }, function () {
+    var errorMessage;
+
+    if (filesWithErrors.length > 0) {
+      errorMessage = filesWithErrors.map(function (file) {
+        return file.sassLint[0].errorCount + ' errors detected in ' + file.relative
+      }).join('\n');
+
+      this.emit('error', new PluginError(PLUGIN_NAME, errorMessage));
+    }
   });
+
   return compile;
 }
-
 
 module.exports = sassLint;


### PR DESCRIPTION
That way, if `sassLint.format()` is used upstream all warning and errors will be logged to console and `sassLint.failOnError()` will emit an error will ALL errors and not when first error is encountered.
