### PR TITLE
Only output formatted content and not empty new-lines

### DIFF
--- a/index.js
+++ b/index.js
@@ -50,7 +50,11 @@ sassLint.format = function () {
       this.emit('error', new PluginError(PLUGIN_NAME, 'Streams are not supported!'));
       return cb();
     }
-    console.log(lint.format(file.sassLint));
+
+    var result = lint.format(file.sassLint);
+    if (result) {
+        console.log(result);
+    }
 
     this.push(file);
     cb();


### PR DESCRIPTION
I found that have a project with a lot of files resulted in the logging of a lot of new lines.
By checking whether sass-lint actually has an outputted results, we only sent that result to the console output.
