### PR TITLE
Update sass-lint to 1.5.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
   "homepage": "https://github.com/sasstools/gulp-sass-lint#readme",
   "dependencies": {
     "gulp-util": "^3.0.6",
-    "sass-lint": "^1.3.2",
+    "sass-lint": "^1.5.1",
     "through2": "^2.0.0"
   },
   "devDependencies": {


### PR DESCRIPTION
Updated the sass-lint dependency to keep up to date. Tests did not reveal any issues.
