### PR TITLE
Fix Ignores & improve documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,6 +100,36 @@ You can pass the path to a custom config file via the `configFile` option. The p
 }
 ```
 
+### Example
+
+The following highlights all of the above options in use
+
+```javascript
+
+'use strict';
+
+var gulp = require('gulp'),
+    sassLint = require('gulp-sass-lint');
+
+gulp.task('default', function () {
+  gulp.src('sass/**/*.s+(a|c)ss')
+    .pipe(sassLint({
+      options: {
+        formatter: 'stylish'
+        'merge-default-rules': false
+      },
+      files: {ignore: '**/*.scss'},
+      rules: {
+        'no-ids': 1,
+        'no-mergeable-selectors': 0
+      },
+      config: 'config/other/.sass-lint.yml'
+    }))
+    .pipe(sassLint.format())
+    .pipe(sassLint.failOnError())
+});
+
+```
 ---
 
 ### sassLint.format()

--- a/README.md
+++ b/README.md
@@ -8,7 +8,9 @@
 npm install gulp-sass-lint --save-dev
 ```
 
-## Using
+## Usage
+
+`gulpfile.js`
 
 ```javascript
 'use strict';
@@ -23,3 +25,89 @@ gulp.task('default', function () {
     .pipe(sassLint.failOnError())
 });
 ```
+
+## API
+
+### sassLint(options)
+
+You can pass an object of options to configure gulp-sass-lint to your specific projects needs the options are listed below.
+
+#### options.options
+
+You can find out more about the specific SassLint options from the [SassLint Documentation](https://github.com/sasstools/sass-lint/tree/develop/docs/options)
+
+```javascript
+{
+  options: {
+    formatter: 'stylish',
+    'merge-default-rules': false
+  }
+}
+```
+
+By default SassLint includes it's own configuration file, if you provide one it attempts to merge everything except for the files section below. If you pass options directly into the plugin they take precedence. The order can be visualised below with the SassLint config being the base.
+
+`options > config file > SassLint default included config`
+
+You can disable this behaviour by setting `merge-default-rules` to false within the `options.options` object that you pass to `gulp-sass-lint` or you can include it in your config file options that you can pass into `gulp-sass-lint` with `options.configFile`.
+
+More info and examples can be found within the SassLint [docs](https://github.com/sasstools/sass-lint/blob/master/docs/options/merge-default-rules.md)
+
+#### options.files
+
+
+Type: `Object`
+
+Within the files object you can specify a glob pattern as a string or an array of glob pattern for both the `include` and `ignore` options. Please note that your include option will currently be ignored as you should be passing the glob patterns / file paths to be linted directly to gulp `gulp.src('sass/**/*.s+(a|c)ss')`. The ignore option however will still be respected if you'd rather specify them in your config rather than in the `gulp.src` method.
+
+```javascript
+{
+  files: {
+    include: '**/*.scss', // This will be ignored by gulp-sass-lint
+    ignore: 'test/**/*.scss' // This will still be respected and read
+  }
+}
+```
+
+#### options.rules
+
+Type: `Object`
+
+You can define which rules you would like to use here and set a severity too. For more information see how to [configure](https://github.com/sasstools/sass-lint/tree/master#rules) and also the SassLint [rules](https://github.com/sasstools/sass-lint/tree/master/docs/rules)
+
+```javascript
+{
+  rules: {
+    'no-ids': 0, // Severity 0 (disabled)
+    'no-mergeable-selectors': 1, // Severity 1 (warning)
+    'hex-length': [
+      2, // Severity 2 (error)
+      {
+        'style': 'long'
+      }
+    ]
+  }
+}
+```
+
+#### options.configFile
+
+You can pass the path to a custom config file via the `configFile` option. The path will be relative to where you're running gulp from.
+
+```javascript
+{
+  configFile: 'app/config/.my-config.yml'
+}
+```
+
+---
+
+### sassLint.format()
+
+Formats the results dependent on your config file or the options you provided to the sassLint task above. The default format is `stylish` but you can choose any of the others that SassLint provides, see the [docs](https://github.com/sasstools/sass-lint/blob/master/docs/options/formatter.md). You can also choose to output to a file from within the options you provide or your config file. See the [output-file docs](https://github.com/sasstools/sass-lint/blob/master/docs/options/output-file.md)
+
+---
+
+### sassLint.failOnError()
+
+Fails the task and emits a gulp error when all files have been linted if an error has been detected (rules set to severity 2).

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ var gulp = require('gulp'),
     sassLint = require('gulp-sass-lint');
 
 gulp.task('default', function () {
-  gulp.src('sass/**/*.s+(a|c)ss')
+  return gulp.src('sass/**/*.s+(a|c)ss')
     .pipe(sassLint())
     .pipe(sassLint.format())
     .pipe(sassLint.failOnError())
@@ -112,7 +112,7 @@ var gulp = require('gulp'),
     sassLint = require('gulp-sass-lint');
 
 gulp.task('default', function () {
-  gulp.src('sass/**/*.s+(a|c)ss')
+  return gulp.src('sass/**/*.s+(a|c)ss')
     .pipe(sassLint({
       options: {
         formatter: 'stylish'

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
   "homepage": "https://github.com/sasstools/gulp-sass-lint#readme",
   "dependencies": {
     "gulp-util": "^3.0.6",
-    "sass-lint": "^1.5.1",
+    "sass-lint": "^1.8.0",
     "through2": "^2.0.0"
   },
   "devDependencies": {


### PR DESCRIPTION
This PR follows on from part 1 of fixing the ability to specify ignored files in gulp-sass-lint. This is dependent on https://github.com/sasstools/sass-lint/pull/711 being successfully merged into sass-lint first and released (hopefully with 1.8 very shortly!)

I've added the ability to specify a config file directly in the options you pass to this plugin or you can continue to specify a config file within the `options.options` object. Added lots of extra documentation too for the whole plugin.

Feedback welcome

closes #34 
