### PR TITLE
Fix incorrect options reference

### DIFF
--- a/index.js
+++ b/index.js
@@ -70,7 +70,7 @@ sassLint.format = function () {
       return cb();
     }
 
-    lint.outputResults(file.sassLint, file.sassConfig);
+    lint.outputResults(file.sassLint, file.userOptions);
 
     this.push(file);
     cb();


### PR DESCRIPTION
Output formatting does not respect the `formatter` option specified in the config hash. This is because an invalid/undefined key (`sassConfig`) is being passed to `lint.outputResults`
