### PR TITLE
Add a callback to failOnError

### DIFF
--- a/index.js
+++ b/index.js
@@ -78,7 +78,7 @@ sassLint.format = function () {
   return compile;
 }
 
-sassLint.failOnError = function () {
+sassLint.failOnError = function (failCb) {
   var filesWithErrors = [];
   var compile = through({objectMode: true}, function (file, encoding, cb) {
     if (file.isNull()) {
@@ -104,7 +104,11 @@ sassLint.failOnError = function () {
         return file.sassLint[0].errorCount + ' errors detected in ' + file.relative
       }).join('\n');
 
-      this.emit('error', new PluginError(PLUGIN_NAME, errorMessage));
+      if (failCb !== undefined) {
+        failCb(errorMessage);
+      } else {
+        this.emit('error', new PluginError(PLUGIN_NAME, errorMessage));
+      }
     }
 
     cb();


### PR DESCRIPTION
re https://github.com/sasstools/gulp-sass-lint/issues/44. just figured I'd get the discussion started. what would be most useful to send back in the failOnError callback?

This sends back the errorMessage, say `2 errors detected in stylesheets/app.sass`. But at least it has a callback now! 
