### PR TITLE
implement failOnWarning

### DIFF
--- a/README.md
+++ b/README.md
@@ -161,3 +161,19 @@ gulp.task('lint_sass_jenkins', function () {
 ### sassLint.failOnError()
 
 Fails the task and emits a gulp error when all files have been linted if an error has been detected (rules set to severity 2).
+
+### sassLint.failOnWarning()
+
+Works as `failOnError()`, but also throws an error if sass contains warnings. This is very useful for CI environments, where you want to prevent a merge if you have warnings. A gulp task may look like:
+
+```
+gulp.task('sasslint', function () {
+  gulp.src('sass/*.s+(a|c)ss')
+    .pipe(sassLint())
+    .pipe(sassLint.format())
+    .pipe(sassLint.failOnError())
+    .pipe(sassLint.failOnWarning())
+});
+```
+
+Gulp will return an exit code for errors and warnings then.

--- a/index.js
+++ b/index.js
@@ -84,7 +84,8 @@ sassLint.format = function (writable) {
   return compile;
 }
 
-sassLint.failOnError = function () {
+sassLint.failOnLevel = function (warnlevel) {
+  var level = warnlevel || 'error'
   var filesWithErrors = [];
   var compile = through({objectMode: true}, function (file, encoding, cb) {
     if (file.isNull()) {
@@ -96,7 +97,7 @@ sassLint.failOnError = function () {
       return cb();
     }
 
-    if (file.sassLint[0].errorCount > 0) {
+    if (file.sassLint[0][level + 'Count'] > 0) {
       filesWithErrors.push(file);
     }
 
@@ -107,7 +108,7 @@ sassLint.failOnError = function () {
 
     if (filesWithErrors.length > 0) {
       errorMessage = filesWithErrors.map(function (file) {
-        return file.sassLint[0].errorCount + ' errors detected in ' + file.relative
+        return file.sassLint[0][level + 'Count'] + ' ' + level + 's detected in ' + file.relative
       }).join('\n');
 
       this.emit('error', new PluginError(PLUGIN_NAME, errorMessage));
@@ -117,6 +118,14 @@ sassLint.failOnError = function () {
   });
 
   return compile;
+}
+
+sassLint.failOnError = function () {
+  return this.failOnLevel('error')
+}
+
+sassLint.failOnWarning = function () {
+  return this.failOnLevel('warning')
 }
 
 module.exports = sassLint;


### PR DESCRIPTION
The addition of `failOnWarning` allows gulp to return an exit code for warnings:

```
$ gulp sasslint
[13:35:22] Using gulpfile ~/Development/test/gulpfile.js
[13:35:22] Starting 'sasslint'...
[13:35:22] Finished 'sasslint' after 8.62 ms

test/report/report.scss
   8:3   warning  Expected `display`, found `font-family`  property-sort-order
  20:12  warning  Trailing semicolons required             trailing-semicolon

✖ 2 problems (0 errors, 2 warnings)


events.js:160
      throw er; // Unhandled 'error' event
      ^
Error: 0 warnings detected in test/report.scss
$ echo $?
1
```

This becomes very handy if gulp is used in CI environments where we want to prevent a merge if the style guide is not met