### PR TITLE
Add error message(s) to console output

### DIFF
--- a/index.js
+++ b/index.js
@@ -106,9 +106,14 @@ sassLint.failOnError = function () {
     var errorMessage;
 
     if (filesWithErrors.length > 0) {
-      errorMessage = filesWithErrors.map(function (file) {
-        return file.sassLint[0].errorCount + ' errors detected in ' + file.relative
-      }).join('\n');
+      const indent = '    ';
+      const newline = `\n${indent.repeat(2)}- `;
+      errorMessage = filesWithErrors.map(file => {
+        const count = file.sassLint[0].errorCount;
+        return `${count} error${count > 1 ? 's' : ''} detected in ` +
+          file.relative + newline +
+          file.sassLint[0].messages.map(m => m.message).join(newline);
+      }).join(`\n${indent}`);
 
       this.emit('error', new PluginError(PLUGIN_NAME, errorMessage));
     }


### PR DESCRIPTION
The message logged on error was only including the error count and the file where the error occurred. Hence I modified the code to print the error message(s) on the next line. The message logged in the console now look like this:
```
Message:
    1 error detected in 4.elements/images.scss
        - Please check validity of the block starting from line #14
    2 errors detected in 6.templates/help-center-nav.scss
        - Please check validity of the block starting from line #46
        - Another error
Details:
    domainEmitter: [object Object]
    domain: [object Object]
    domainThrown: false
```

...instead of:
```
Message:
    1 errors detected in 4.elements/images.scss
2 errors detected in 6.templates/help-center-nav.scss
Details:
    domainEmitter: [object Object]
    domain: [object Object]
    domainThrown: false
```

My modifications are made in [ES6](http://www.google.com/search?q=javascript+es6).